### PR TITLE
1.0.4

### DIFF
--- a/PSEncrypt/PSEncrypt.psd1
+++ b/PSEncrypt/PSEncrypt.psd1
@@ -4,7 +4,7 @@
 	RootModule        = 'PSEncrypt.psm1'
 
 	# Version number of this module.
-	ModuleVersion     = '1.0.3'
+	ModuleVersion     = '1.0.4'
 
 	# Supported PSEditions
 	# CompatiblePSEditions = @()

--- a/PSEncrypt/changelog.md
+++ b/PSEncrypt/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## 1.0.4 (2023-05-22)
+
++ Fix: Windows PowerShell compatibility - throws error `Method invocation failed because [System.Security.Cryptography.X509Certificates.PublicKey] does not contain a method named
+'GetRSAPublicKey'`
+
 ## 1.0.3 (2023-05-11)
 
 + New: Set-PseCertificate - allows selecting the certificate selection criteria for your own certificate.

--- a/PSEncrypt/functions/Protect-PseDocument.ps1
+++ b/PSEncrypt/functions/Protect-PseDocument.ps1
@@ -92,8 +92,11 @@
 			)
 
 			$bytes = [System.Text.Encoding]::UTF8.GetBytes($Content)
-			$bytesEncrypted = $Contact.Certificate.PublicKey.GetRSAPublicKey().Encrypt($bytes, [System.Security.Cryptography.RSAEncryptionPadding]::Pkcs1)
-			$bytesSignature = $OwnCertificate.PrivateKey.SIgnData($bytesEncrypted, [System.Security.Cryptography.HashAlgorithmName]::SHA512, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+			$publicKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPublicKey($Contact.Certificate)
+			$privateKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($OwnCertificate)
+
+			$bytesEncrypted = $publicKey.Encrypt($bytes, [System.Security.Cryptography.RSAEncryptionPadding]::Pkcs1)
+			$bytesSignature = $privateKey.SignData($bytesEncrypted, [System.Security.Cryptography.HashAlgorithmName]::SHA512, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
 
 			@{
 				Name            = $Name
@@ -126,8 +129,11 @@
 			)
 
 			$bytes = [System.IO.File]::ReadAllBytes($Path)
-			$bytesEncrypted = $Contact.Certificate.PublicKey.GetRSAPublicKey().Encrypt($bytes, [System.Security.Cryptography.RSAEncryptionPadding]::Pkcs1)
-			$bytesSignature = $OwnCertificate.PrivateKey.SignData($bytesEncrypted, [System.Security.Cryptography.HashAlgorithmName]::SHA512, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+			$publicKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPublicKey($Contact.Certificate)
+			$privateKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($OwnCertificate)
+
+			$bytesEncrypted = $publicKey.Encrypt($bytes, [System.Security.Cryptography.RSAEncryptionPadding]::Pkcs1)
+			$bytesSignature = $privateKey.SignData($bytesEncrypted, [System.Security.Cryptography.HashAlgorithmName]::SHA512, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
 
 			$fileName = Split-Path -Path $Path -Leaf
 			$data = @{

--- a/PSEncrypt/functions/Set-PseCertificate.ps1
+++ b/PSEncrypt/functions/Set-PseCertificate.ps1
@@ -50,9 +50,9 @@
 
 	process {
 		$configuration = @{
-			CertThumbprint = ''
+			CertThumbprint   = ''
 			CertFriendlyName = ''
-			CertSubject = ''
+			CertSubject      = ''
 		}
 		if ($Thumbprint) { $configuration.CertThumbprint = $Thumbprint }
 		if ($FriendlyName) { $configuration.CertFriendlyName = $FriendlyName }

--- a/PSEncrypt/functions/Unprotect-PseDocument.ps1
+++ b/PSEncrypt/functions/Unprotect-PseDocument.ps1
@@ -102,14 +102,16 @@
 				return
 			}
 
-			$isFromSender = $senderCert.PublicKey.GetRSAPublicKey().VerifyData($bytesData, $bytesSignature, [System.Security.Cryptography.HashAlgorithmName]::SHA512, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+			$senderPK = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPublicKey($senderCert)
+			$isFromSender = $senderPK.VerifyData($bytesData, $bytesSignature, [System.Security.Cryptography.HashAlgorithmName]::SHA512, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
 			if (-not $isFromSender) {
 				$record = New-ErrorRecord -Message "Invalid signature! $($config.Name) could not be verified to come from $($senderCert.Subject) ($($senderCert.Thumbprint))!" -ErrorID 'InvalidSignature' -Category InvalidData -Target $config
 				$Cmdlet.WriteError($record)
 				return
 			}
 
-			try { $decryptedBytes = $recipientCert.PrivateKey.Decrypt($bytesData, [System.Security.Cryptography.RSAEncryptionPadding]::Pkcs1) }
+			$recipientPK = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($recipientCert)
+			try { $decryptedBytes = $recipientPK.Decrypt($bytesData, [System.Security.Cryptography.RSAEncryptionPadding]::Pkcs1) }
 			catch {
 				$record = New-ErrorRecord -Message "Error decrypting data! $($config.Name) could not be decrypted wth $($recipientCert.Subject) ($($recipientCert.Thumbprint)): $_" -ErrorID 'InvalidCert' -Category InvalidData -Target $config
 				$Cmdlet.WriteError($record)


### PR DESCRIPTION
+ Fix: Windows PowerShell compatibility - throws error `Method invocation failed because [System.Security.Cryptography.X509Certificates.PublicKey] does not contain a method named
'GetRSAPublicKey'`